### PR TITLE
Fixed conflict with dynamically added placeholders and displaying pages > settings.maxVisible

### DIFF
--- a/lib/jquery.bootpag.js
+++ b/lib/jquery.bootpag.js
@@ -33,6 +33,7 @@
                 wrapClass: 'pagination',
                 activeClass: 'active',
                 disabledClass: 'disabled',
+                hiddenClass: 'hide',
                 nextClass: 'next',
                 prevClass: 'prev',
 		        lastClass: 'last',
@@ -113,7 +114,7 @@
                     lp = index + 1 + vis + d;
                     $(this)
                         .attr('data-lp', lp)
-                        .toggle(lp <= settings.total)
+                        .toggleClass(settings.hiddenClass, lp > settings.total)
                         .find('a').html(lp).attr('href', href(lp));
                 });
                 $currPage = $page.filter('[data-lp='+page+']');


### PR DESCRIPTION
Issue:

Occurs when adding placeholder in JS and initializing Bootpag before appending to page. When a pagination page value is greater than maxVisible, pagination is displayed vertically instead of horizontally.

Change:

Added a new setting 'hiddenClass', default set to Bootstrap's 'hide', and replaced toggle with toggleClass.

Example:

http://codepen.io/anon/pen/GJzMMz

Screenshots:

<img width="123" alt="screen shot 2015-08-05 at 12 49 29 pm" src="https://cloud.githubusercontent.com/assets/3741698/9096526/4b6a23ea-3b83-11e5-9243-df2c5a2f4d80.png">

<img width="537" alt="screen shot 2015-08-05 at 12 50 38 pm" src="https://cloud.githubusercontent.com/assets/3741698/9096537/530bac2c-3b83-11e5-9f79-d309fd7165de.png">
