### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ bootpag - dynamic pagination
 
 This jQuery plugin helps you create dynamic pagination with [Bootstrap](http://getbootstrap.com/) or in any other html pages.
 
-#Example
+# Example
 
 Snippet that dynamic loads number of pages.
 More examples can be found on [project homepage](http://botmonster.com/jquery-bootpag/)
@@ -26,7 +26,7 @@ $('#pagination-here').bootpag({
 });
 
 ```
-#License
+# License
 
 Plugin available under MIT license (See LICENSE file)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
