### PR TITLE
Add "main" param to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,6 @@
     "homepage": "http://botmonster.com/jquery-bootpag",
     "dependencies": {
         "jquery": ">=1.6"
-    }
+    },
+    "main": "./lib/jquery.bootpag.min.js"
 }


### PR DESCRIPTION
TypeScript compiler cannot resolve this dependency because of the missing "main" param.